### PR TITLE
feat(ui): Add tabs for portfolio and datum to sidepanel

### DIFF
--- a/client/components/Form/Checkbox/Checkbox.models.ts
+++ b/client/components/Form/Checkbox/Checkbox.models.ts
@@ -1,4 +1,4 @@
-import { FormControl } from 'store/hooks/form/Form.models';
+import { FormControl } from 'store/models/form';
 
 export interface CheckboxProps {
   label: string;

--- a/client/components/Form/Checkbox/Checkbox.scss
+++ b/client/components/Form/Checkbox/Checkbox.scss
@@ -3,7 +3,7 @@
   width: 0;
   visibility: hidden;
 
-  &:checked + .checkbox .checkbox-button {
+  &:checked + .checkbox .checkbox-btn {
     color: #1e7ba4;
   }
 }
@@ -15,15 +15,15 @@
   font-size: 16px;
   cursor: pointer;
 
-  &:active .checkbox-button {
+  &:active .checkbox-btn {
     box-shadow: inset 0 0 0 2px #1e7ba48f;
   }
 
-  &:hover .checkbox-button {
+  &:hover .checkbox-btn {
     border: 1px solid #1e7ba4;
   }
 
-  .checkbox-button {
+  .checkbox-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/client/components/Form/Checkbox/Checkbox.tsx
+++ b/client/components/Form/Checkbox/Checkbox.tsx
@@ -25,7 +25,7 @@ const Checkbox: FC<CheckboxProps> = ({ label, control }) => {
         onClick={() => markAsTouched()}
       />
       <label htmlFor={`${label}-checkbox`} className={styles.checkbox}>
-        <button type="button" className={styles.checkboxButton}>&#x2714;</button>
+        <span className={styles.checkboxBtn}>&#x2714;</span>
         {label}
       </label>
       {errors.length ? <p className={styles.errorMessage}>{errors[0].message}</p> : null}

--- a/client/components/Form/DatePicker/DatePicker.models.ts
+++ b/client/components/Form/DatePicker/DatePicker.models.ts
@@ -1,4 +1,4 @@
-import { FormControl } from 'store/hooks/form/Form.models';
+import { FormControl } from 'store/models/form';
 
 export interface DatePickerProps {
   label: string;

--- a/client/components/Form/Select/Select.models.ts
+++ b/client/components/Form/Select/Select.models.ts
@@ -1,4 +1,4 @@
-import { FormControl } from 'store/hooks/form/Form.models';
+import { FormControl } from 'store/models/form';
 
 export interface SelectProps {
   label: string;

--- a/client/components/Form/Select/Select.scss
+++ b/client/components/Form/Select/Select.scss
@@ -32,11 +32,13 @@
   .menu {
     position: absolute;
     z-index: 10;
+    max-height: 210px;
     width: inherit;
     padding: 10px 0;
     background: #fff;
     border: 1px solid #ccc;
     box-shadow: 0 0 4px 1px rgba(252, 120, 120, 0.01), 0 3px 24px rgba(0, 0, 0, 0.2);
+    overflow: auto;
 
     button {
       height: 40px;

--- a/client/components/Form/TextInput/TextInput.models.ts
+++ b/client/components/Form/TextInput/TextInput.models.ts
@@ -1,6 +1,8 @@
-import { FormControl } from 'store/hooks/form/Form.models';
+import { FormControl } from 'store/models/form';
+import { ReactNode } from 'react';
 
 export interface TextInputProps {
   label: string;
-  control: FormControl<string>;
+  control: FormControl<string | number>;
+  children?: ReactNode;
 }

--- a/client/components/Form/TextInput/TextInput.scss
+++ b/client/components/Form/TextInput/TextInput.scss
@@ -6,7 +6,7 @@
   font-size: 14px;
   line-height: 19px;
 
-  .icon {
+  > span:first-child {
     position: absolute;
     top: 29px;
     left: 10px;
@@ -14,13 +14,17 @@
     margin: unset;
     color: #999;
     user-select: none;
+
+    & + input {
+      padding-left: 25px;
+    }
   }
 
   input {
     display: block;
     height: 40px;
     width: inherit;
-    padding: 10px 10px 10px 25px;
+    padding: 10px;
     font-size: 14px;
     font-weight: 300;
     border: 1px solid #ccc;

--- a/client/components/Form/TextInput/TextInput.tsx
+++ b/client/components/Form/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import { getClassName } from 'utils/react-util';
 import { TextInputProps } from './TextInput.models';
 import styles from './TextInput.scss';
 
-const TextInput: FC<TextInputProps> = ({ label, control }) => {
+const TextInput: FC<TextInputProps> = ({ label, control, children }) => {
   const {
     value,
     patchValue,
@@ -25,7 +25,7 @@ const TextInput: FC<TextInputProps> = ({ label, control }) => {
         })}
       >
         {label}
-        <p className={styles.icon}>$</p>
+        {children}
         <input
           id={`${label}-text-input`}
           type="text"

--- a/client/components/Sidebar/Sidebar.tsx
+++ b/client/components/Sidebar/Sidebar.tsx
@@ -50,7 +50,9 @@ const Sidebar: FC = () => {
             portfolios={portfolios}
             title={label}
           />
-        ) : null
+        ) : (
+          null
+        )
       ))}
       {isMenuOpen && (
         <Dropdown

--- a/client/components/Sidepanel/DataPointForm/DataPointForm.tsx
+++ b/client/components/Sidepanel/DataPointForm/DataPointForm.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/models/store';
+import { useFormControl } from 'store/hooks/form/useFormControl';
+import { portfolioListByNameSelector } from 'store/selectors/portfolios/PortfolioSelector';
+import TextInput from 'components/Form/TextInput/TextInput';
+import Select from 'components/Form/Select/Select';
+import DatePicker from 'components/Form/DatePicker/DatePicker';
+
+const defaultDropdown = 'Select';
+const defaultText = '';
+
+const DataPointForm: FC = () => {
+  const portfolioListByName = useSelector(portfolioListByNameSelector);
+  const dataPoint = useSelector((state: AppState) => state.sidepanel.dataPoint);
+
+  const date = useFormControl(defaultDropdown);
+  const portfolio = useFormControl(defaultDropdown);
+  const balance = useFormControl<number | string>(defaultText);
+  const deposit = useFormControl<number | string>(defaultText);
+  const withdrawal = useFormControl<number | string>(defaultText);
+
+  useEffect(() => {
+    date.reset(dataPoint.date || defaultDropdown);
+    portfolio.reset(dataPoint.portfolio || defaultDropdown);
+    balance.reset(dataPoint.balance || defaultText);
+    deposit.reset(dataPoint.deposit || defaultText);
+    withdrawal.reset(dataPoint.withdrawal || defaultText);
+  }, [dataPoint]);
+
+  return (
+    <>
+      <DatePicker label="Date" control={date} />
+      <Select label="Portfolio" control={portfolio} menuItems={portfolioListByName} />
+      <TextInput label="Balance" control={balance}>
+        <span>$</span>
+      </TextInput>
+      <TextInput label="Deposit" control={deposit}>
+        <span>$</span>
+      </TextInput>
+      <TextInput label="Withdrawal" control={withdrawal}>
+        <span>$</span>
+      </TextInput>
+    </>
+  );
+};
+
+export default DataPointForm;

--- a/client/components/Sidepanel/PortfolioForm/PortfolioForm.tsx
+++ b/client/components/Sidepanel/PortfolioForm/PortfolioForm.tsx
@@ -1,0 +1,67 @@
+import React, { FC, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/models/store';
+import { useFormControl } from 'store/hooks/form/useFormControl';
+// import { portfolioListByNameSelector } from 'store/selectors/portfolios/PortfolioSelector';
+// import { IPortfolio } from 'store/models/portfolio';
+import TextInput from 'components/Form/TextInput/TextInput';
+import Select from 'components/Form/Select/Select';
+import Checkbox from 'components/Form/Checkbox/Checkbox';
+// import { find } from 'utils/collection-util';
+
+const defaultDropdown = 'Select';
+const defaultText = '';
+const brokerageList = [
+  'Ally Bank',
+  'Charles Schwab',
+  'E*Trade',
+  'Fidelity',
+  'Health Equity',
+  'M1 Finance',
+  'T Rowe Price',
+  'Robinhood',
+  'Vanguard',
+  'Wells Fargo',
+];
+
+const PortfolioForm: FC = () => {
+  // const portfolioListByName = useSelector(portfolioListByNameSelector);
+  const portfolioForm = useSelector((state: AppState) => state.sidepanel.portfolio);
+  // const portfolioList = useSelector((state: AppState) => state.portfolio.list);
+
+  const portfolio = useFormControl(defaultDropdown);
+  const name = useFormControl<number | string>(defaultText);
+  const brokerage = useFormControl(defaultDropdown);
+  const retirement = useFormControl(false);
+  const savings = useFormControl(false);
+
+  useEffect(() => {
+    portfolio.patchValue(defaultDropdown);
+    name.patchValue(portfolioForm.name || defaultText);
+    brokerage.patchValue(portfolioForm.brokerage || defaultDropdown);
+    retirement.patchValue(portfolioForm.isRetirement);
+    savings.patchValue(portfolioForm.isSavings);
+  }, [portfolioForm]);
+
+  // useEffect(() => {
+  //   if (portfolio.value !== defaultDropdown) {
+  //     const selectedPortfolio: IPortfolio = find(portfolioList, { name: portfolio.value });
+  //     name.patchValue(selectedPortfolio.name);
+  //     brokerage.patchValue(selectedPortfolio.brokerage);
+  //     retirement.patchValue(selectedPortfolio.isRetirement);
+  //     savings.patchValue(selectedPortfolio.isSavings);
+  //   }
+  // }, [portfolio.value]);
+
+  return (
+    <>
+      {/* <Select label="Edit Portfolio" control={portfolio} menuItems={portfolioListByName} /> */}
+      <TextInput label="Name" control={name} />
+      <Select label="Brokerage" control={brokerage} menuItems={brokerageList} />
+      <Checkbox label="Retirement" control={retirement} />
+      <Checkbox label="Savings" control={savings} />
+    </>
+  );
+};
+
+export default PortfolioForm;

--- a/client/components/Sidepanel/Sidepanel.scss
+++ b/client/components/Sidepanel/Sidepanel.scss
@@ -18,7 +18,7 @@
 
 .header {
   position: relative;
-  padding: 20px;
+  padding: 20px 20px 0;
   background: #f8f8f8;
 
   h1 {
@@ -44,7 +44,7 @@
 }
 
 .content {
-  height: calc(100vh - 86px - 78px - 80px);
+  height: calc(100vh - 107px - 78px - 80px);
   width: 100%;
   padding: 20px;
   overflow: auto;
@@ -56,7 +56,6 @@
   width: 100%;
   max-width: 280px;
   margin: 0 auto;
-  padding: 10px;
 }
 
 .overlay {
@@ -68,7 +67,7 @@
   width: 100%;
   padding: 20px;
   background: #f8f8f8;
-  border-top: 4px solid #cecece;
+  border-top: 2px solid #cecece;
   text-align: right;
 }
 
@@ -93,4 +92,30 @@
   color: #fff;
   background: #1591b6;
   border-radius: 20px;
+}
+
+.nav ul {
+  display: flex;
+  width: calc(100% + 20px);
+  margin: unset;
+  margin-top: 20px;
+  padding: unset;
+  list-style: none;
+  border-bottom: 1px solid #999;
+}
+
+.tab {
+  height: 28px;
+  margin-right: 20px;
+  padding: 0;
+  color: #666;
+  font-size: 18px;
+  line-height: 100%;
+  text-align: center;
+  cursor: pointer;
+
+  &--selected {
+    color: #1591b6;
+    border-bottom: 2px solid #1591b6;
+  }
 }

--- a/client/components/Sidepanel/Sidepanel.tsx
+++ b/client/components/Sidepanel/Sidepanel.tsx
@@ -9,28 +9,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { fromEvent, Subscription } from 'rxjs';
 import { getClassName } from 'utils/react-util';
 import { AppState } from 'store/models/store';
-import { updateSidepanelStatusAction } from 'store/actions/sidepanel';
-import { useFormControl } from 'store/hooks/form/useFormControl';
-import { portfolioListByNameSelector } from 'store/selectors/portfolios/PortfolioSelector';
-import TextInput from 'components/Form/TextInput/TextInput';
-import Select from 'components/Form/Select/Select';
-import DatePicker from 'components/Form/DatePicker/DatePicker';
+import { SidepanelTab } from 'store/models/sidepanel';
+import { updateSidepanelStatusAction, updateSidepanelTabAction } from 'store/actions/sidepanel';
 import Portal from 'components/Portal/Portal';
-import Checkbox from 'components/Form/Checkbox/Checkbox';
+import DataPointForm from './DataPointForm/DataPointForm';
+import PortfolioForm from './PortfolioForm/PortfolioForm';
 import styles from './Sidepanel.scss';
 
 const Sidepanel: FC = () => {
   const isPanelOpen = useSelector((state: AppState) => state.sidepanel.isOpen);
-  const portfolioListByName = useSelector(portfolioListByNameSelector);
+  const selectedTab = useSelector((state: AppState) => state.sidepanel.selectedTab);
   const dispatch = useDispatch();
   const sidepanel = useRef(null);
-
-  const portfolio = useFormControl('Select');
-  const date = useFormControl('Select');
-  const balance = useFormControl('');
-  const deposit = useFormControl('');
-  const withdrawal = useFormControl('');
-  const group = useFormControl(false);
 
   useEffect(() => {
     const subscription: Subscription = new Subscription();
@@ -48,11 +38,6 @@ const Sidepanel: FC = () => {
 
   const onDelete = useCallback(() => {
     dispatch(updateSidepanelStatusAction(false));
-    portfolio.reset();
-    date.reset();
-    balance.reset();
-    deposit.reset();
-    withdrawal.reset();
   }, []);
 
   const onAdd = useCallback((event: MouseEvent) => {
@@ -77,15 +62,32 @@ const Sidepanel: FC = () => {
           >
             x
           </button>
+          <nav className={styles.nav}>
+            <ul>
+              {Object.values(SidepanelTab).map(tab => (
+                <li key={tab}>
+                  <button
+                    type="button"
+                    onClick={() => dispatch(updateSidepanelTabAction(tab))}
+                    className={getClassName({
+                      [styles.tab]: true,
+                      [styles.tabSelected]: tab === selectedTab,
+                    })}
+                  >
+                    {tab}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
         </header>
         <section className={styles.content}>
           <form className={styles.form}>
-            <DatePicker label="Date" control={date} />
-            <Select label="Portfolio" control={portfolio} menuItems={portfolioListByName} />
-            <TextInput label="Balance" control={balance} />
-            <TextInput label="Deposit" control={deposit} />
-            <TextInput label="Withdrawal" control={withdrawal} />
-            <Checkbox label="Group" control={group} />
+            {selectedTab === SidepanelTab.DataPoint ? (
+              <DataPointForm />
+            ) : (
+              <PortfolioForm />
+            )}
             <section className={styles.overlay}>
               <button
                 type="button"

--- a/client/store/actions/sidepanel.ts
+++ b/client/store/actions/sidepanel.ts
@@ -1,8 +1,16 @@
 import { createAction } from 'utils/action-util';
+import { SidepanelTab } from '../models/sidepanel';
 
 export const UPDATE_SIDEPANEL_STATUS = '[Sidepanel] Update Open Status';
 
 export const updateSidepanelStatusAction = (isOpen: boolean) => createAction(
   UPDATE_SIDEPANEL_STATUS,
   isOpen,
+);
+
+export const UPDATE_SIDEPANEL_TAB = '[Sidepanel] Update Open Tab';
+
+export const updateSidepanelTabAction = (selectedTab: SidepanelTab) => createAction(
+  UPDATE_SIDEPANEL_TAB,
+  selectedTab,
 );

--- a/client/store/hooks/form/useFormControl.ts
+++ b/client/store/hooks/form/useFormControl.ts
@@ -4,7 +4,7 @@ import {
   FormOption,
   Validator,
   ValidationError,
-} from './Form.models';
+} from 'store/models/form';
 
 export const useFormControl = <T = string | boolean>(
   // typescript non-issue. Parens are added already, but Generic type causing confusion
@@ -58,10 +58,10 @@ export const useFormControl = <T = string | boolean>(
     else _setErrors([newErrors]);
   };
 
-  const reset = () => {
+  const reset = (newValue?: T) => {
     setTouched(false);
     setDirty(false);
-    setValue(defaultValue);
+    setValue(newValue || defaultValue);
   };
 
   return {

--- a/client/store/models/form.ts
+++ b/client/store/models/form.ts
@@ -17,7 +17,7 @@ export interface FormControl<T> {
   markAsTouched: (options?: FormOption) => void;
   markAsDirty: (options?: FormOption) => void;
   setErrors: (errors: ValidationError | ValidationError[]) => void;
-  reset: () => void;
+  reset: (newValue?: T) => void;
 }
 
 export interface FormOption {

--- a/client/store/models/sidepanel.ts
+++ b/client/store/models/sidepanel.ts
@@ -1,3 +1,26 @@
+export enum SidepanelTab {
+  Portfolio = 'Portfolio',
+  DataPoint = 'Data Point',
+}
+
 export interface SidepanelState {
   isOpen: boolean;
+  selectedTab: SidepanelTab;
+  dataPoint: PortfolioDataForm;
+  portfolio: IPortfolioForm;
+}
+
+export interface PortfolioDataForm {
+  date: string;
+  portfolio: string;
+  balance?: number;
+  deposit?: number;
+  withdrawal?: number;
+}
+
+export interface IPortfolioForm {
+  name: string;
+  brokerage: string;
+  isRetirement: boolean;
+  isSavings: boolean;
 }

--- a/client/store/reducers/sidepanel.ts
+++ b/client/store/reducers/sidepanel.ts
@@ -1,10 +1,30 @@
 import { Reducer } from 'redux';
-import { SidepanelState } from 'store/models/sidepanel';
+import {
+  SidepanelState,
+  SidepanelTab,
+  PortfolioDataForm,
+  IPortfolioForm,
+} from 'store/models/sidepanel';
 import { FluxAction } from 'store/models/action';
 import * as SidepanelAction from 'store/actions/sidepanel';
 
+const defaultDataPoint: PortfolioDataForm = {
+  date: null,
+  portfolio: null,
+};
+
+const defaultPortfolio: IPortfolioForm = {
+  name: null,
+  brokerage: null,
+  isRetirement: false,
+  isSavings: false,
+};
+
 export const initialSidepanelState: SidepanelState = {
   isOpen: false,
+  selectedTab: SidepanelTab.Portfolio,
+  dataPoint: defaultDataPoint,
+  portfolio: defaultPortfolio,
 };
 
 export const sidepanelReducer: Reducer<SidepanelState, FluxAction<any>> = (
@@ -16,6 +36,11 @@ export const sidepanelReducer: Reducer<SidepanelState, FluxAction<any>> = (
       return {
         ...state,
         isOpen: action.payload,
+      };
+    case SidepanelAction.UPDATE_SIDEPANEL_TAB:
+      return {
+        ...state,
+        selectedTab: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
- Modify text input to allow option left icon
- Create seperate forms for new datum and portfolio
- Add logic for switch forms through tabs in redux state

Resolves PFMS-91